### PR TITLE
Add HaGeZi Blocklists

### DIFF
--- a/blocklists/hagezi-multi-light.json
+++ b/blocklists/hagezi-multi-light.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi LIGHT",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Hand brush - Cleans the Internet and protects your privacy! Blocks Ads, Tracking, Metrics, some Malware and Fake.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/light.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/hagezi-multi-normal.json
+++ b/blocklists/hagezi-multi-normal.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi NORMAL",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/multi.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/hagezi-multi-pro-plus.json
+++ b/blocklists/hagezi-multi-pro-plus.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi PRO plus",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Sweeper - Aggressive cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.plus.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/hagezi-multi-pro.json
+++ b/blocklists/hagezi-multi-pro.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi PRO",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Big broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/hagezi-multi-ultimate.json
+++ b/blocklists/hagezi-multi-ultimate.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Multi ULTIMATE",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "Ultimate Sweeper - Strictly cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking (+Referral), Metrics, Telemetry, Phishing, Malware, Scam, Free Hoster, Fake, Coins and other Crap.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/ultimate.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Hi @romaincointepas,
as requested my pull request in the new repository.

As requested by the users, I have added all versions of my blocklists. Light, Normal, Pro, Pro++ and the new Ultimate.
So no wishes should remain unfulfilled.

Details: https://github.com/hagezi/dns-blocklists

Thanks for your support,
Gerd