### PR TITLE
Create antispam-it.json

### DIFF
--- a/blocklists/antispam-it.json
+++ b/blocklists/antispam-it.json
@@ -1,0 +1,9 @@
+{
+  "name": "antispam-IT",
+  "website": "https://github.com/marco-acorte/antispam-it",
+  "description": "Strictly blocks advertisements networks, malwares, spams, statistics & trackers included in phishing/malware/spam campaign harassing poor italian (domain.it) mailboxes. Manually verified, and is updated regularly.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/marco-acorte/antispam-it/main/antispam-it.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
I think that this public and well maintained list may be interesting for other users.


- "name": "antispam-IT",
- "website": "https://github.com/marco-acorte/antispam-it",
- "description": "Strictly blocks advertisements networks, malware , spams, statistics & trackers included in phishing/malware/spam campaign harassing poor Italian (domain.it) mailboxes. Manually verified, and is updated regularly.",
- "source": 
	- "url": "https://raw.githubusercontent.com/marco-acorte/antispam-it/main/antispam-it.txt",
	- "format": "domains"