### PR TITLE
Add AdGuard Spanish/Portuguese filter

### DIFF
--- a/blocklists/adguard-spanish-portuguese-filter.json
+++ b/blocklists/adguard-spanish-portuguese-filter.json
@@ -1,0 +1,9 @@
+{
+  "name": "AdGuard Spanish/Portuguese filter",
+  "website": "https://kb.adguard.com/en/general/adguard-ad-filters#filters",
+  "description": "Removes ads from websites in Spanish and Portuguese.",
+  "source": {
+    "url": "https://filters.adtidy.org/extension/chromium/filters/9.txt",
+    "format": "abp"
+  }
+}


### PR DESCRIPTION
I think this list should be included. Did the PR as it was suggested in the README. Coming from this Issue I created in the old/other repo (https://github.com/nextdns/metadata/issues/1177). Saw on a PR (https://github.com/nextdns/metadata/pull/1160) that this is the repo that's being used now for block lists.