### PR TITLE
OISD host change to official Github repo

### DIFF
--- a/blocklists/oisd.json
+++ b/blocklists/oisd.json
@@ -3,7 +3,7 @@
   "website": "https://oisd.nl",
   "description": "Internet's #1 domain blocklist. Blocks Ads, Mobile Ads, Phishing, Malvertising, Malware, Tracking, Telemetry, CryptoJacking, Analytics, Spyware, Ransomware, Exploit, Fraud, Abuse, Scam, Spam, Hijack, Misleading Marketing.",
   "source": {
-    "url": "https://dblw.oisd.nl",
+    "url": "https://raw.githubusercontent.com/sjhgvr/oisd/main/dblw_full.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
I'm making a PR addressing this issue (made PR by mistake) https://github.com/nextdns/blocklists/pull/82 and this conversation on Reddit (https://www.reddit.com/r/nextdns/comments/10ep7fk/oisd_list_last_updated_2_days_ago/)