### PR TITLE
Change hufilter source to one that is meant for dns

### DIFF
--- a/blocklists/hufilter.json
+++ b/blocklists/hufilter.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hufilter/hufilter",
   "description": "Block hungarian ads.",
   "source": {
-    "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter.txt",
-    "format": "abp"
+    "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter-dns.txt",
+    "format": "domains"
   }
 }


### PR DESCRIPTION
The original source is more meant for an adblocker and has very few non cosmetic entries. This dns source is more fitting as it only includes domains