### PR TITLE
HaGeZi: Change the source URL to GitLab - Counteracting the GitHub RAW Cache Issue

### DIFF
--- a/blocklists/hagezi-multi-light.json
+++ b/blocklists/hagezi-multi-light.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Hand brush - Cleans the Internet and protects your privacy! Blocks Ads, Tracking, Metrics, some Malware and Fake.",
   "source": {
-    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/light.txt",
+    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/light.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-light.json
+++ b/blocklists/hagezi-multi-light.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Hand brush - Cleans the Internet and protects your privacy! Blocks Ads, Tracking, Metrics, some Malware and Fake.",
   "source": {
-    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/light.txt",
+    "url": "https://hagezi.gitlab.io/mirror/dns-blocklists/wildcard/light.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-normal.json
+++ b/blocklists/hagezi-multi-normal.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/multi.txt",
+    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/multi.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-normal.json
+++ b/blocklists/hagezi-multi-normal.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/multi.txt",
+    "url": "https://hagezi.gitlab.io/mirror/dns-blocklists/wildcard/multi.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-pro-plus.json
+++ b/blocklists/hagezi-multi-pro-plus.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Sweeper - Aggressive cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.plus.txt",
+    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/pro.plus.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-pro-plus.json
+++ b/blocklists/hagezi-multi-pro-plus.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Sweeper - Aggressive cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/pro.plus.txt",
+    "url": "https://hagezi.gitlab.io/mirror/dns-blocklists/wildcard/pro.plus.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-pro.json
+++ b/blocklists/hagezi-multi-pro.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Big broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/pro.txt",
+    "url": "https://hagezi.gitlab.io/mirror/dns-blocklists/wildcard/pro.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-pro.json
+++ b/blocklists/hagezi-multi-pro.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Big broom - Cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking, Metrics, Telemetry, Phishing, Malware, Scam, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/pro.txt",
+    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/pro.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-ultimate.json
+++ b/blocklists/hagezi-multi-ultimate.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Ultimate Sweeper - Strictly cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking (+Referral), Metrics, Telemetry, Phishing, Malware, Scam, Free Hoster, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/ultimate.txt",
+    "url": "https://hagezi.gitlab.io/mirror/dns-blocklists/wildcard/ultimate.txt",
     "format": "domains"
   }
 }

--- a/blocklists/hagezi-multi-ultimate.json
+++ b/blocklists/hagezi-multi-ultimate.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hagezi/dns-blocklists",
   "description": "Ultimate Sweeper - Strictly cleans the Internet and protects your privacy! Blocks Ads, Affiliate, Tracking (+Referral), Metrics, Telemetry, Phishing, Malware, Scam, Free Hoster, Fake, Coins and other Crap.",
   "source": {
-    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/ultimate.txt",
+    "url": "https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/ultimate.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
Hi @romaincointepas,

since a few days there is a problem with the GitHub RAW Cache at different repositories and apparently only in certain regions. Probably depending on which server you land on when `raw.githubusercontent.com` is resolved via DNS, you don't get the current list version but an outdated state from the previous day. The RAW cache doesn't seem to be up to date everywhere. My repository and lists are affected by this which is why they are not up to date in NextDNS.

See also: https://github.com/orgs/community/discussions/46691

Using NextDNS as DNS I could reproduce the problem, calling a RAW version of one of my lists returns an outdated version. If I use another DNS like Google, I get the current RAW version. Pretty crazy.

So I created a GitLab mirror and adjusted the source URLs of my lists, please merge.

Thanks and have a nice rest of the weekend,
Gerd
