### PR TITLE
Add OISD-nsfw blocklist

### DIFF
--- a/blocklists/oisd-nsfw
+++ b/blocklists/oisd-nsfw
@@ -1,0 +1,9 @@
+{
+  "name": "OISD nsfw",
+  "website": "https://oisd.nl",
+  "description": "An extension to basic OISD blocklist. Blocks Shock / Porn / Adult",
+  "source": {
+    "url": "https://raw.githubusercontent.com/sjhgvr/oisd/main/domainswild_nsfw.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/oisd-nsfw
+++ b/blocklists/oisd-nsfw
@@ -1,7 +1,7 @@
 {
   "name": "OISD nsfw",
   "website": "https://oisd.nl",
-  "description": "An extension to basic OISD blocklist. Blocks Shock / Porn / Adult",
+  "description": "An extension to basic OISD blocklist. Blocks Shock / Porn / Adult content.",
   "source": {
     "url": "https://raw.githubusercontent.com/sjhgvr/oisd/main/domainswild_nsfw.txt",
     "format": "domains"


### PR DESCRIPTION
Could [OISD NSFW blocklist](https://oisd.nl/downloads) be added as an option to the blocklists available? There are just **soooo many** sites missing in the default "porn" list currently used in NextDNS that it's basically useless for any porn/adult content control.

We would really like to purchase NextDNS Business/ Education but with the adult content protection being basically non-existent we will have to go search for a different provider. Just a simple search for the highest traffic adult sites and testing them on your filter shows dozens passing through. The OIDS list is the most extensive and I found it to contain most sites the default NextDNS list isn't catching.