### PR TITLE
Add Hagezi Threat Intelligence Feeds

### DIFF
--- a/blocklists/hagezi-threat-intelligence-feeds.json
+++ b/blocklists/hagezi-threat-intelligence-feeds.json
@@ -1,0 +1,9 @@
+{
+  "name": "HaGeZi - Threat Intelligence Feeds",
+  "website": "https://github.com/hagezi/dns-blocklists",
+  "description": "A blocklist for blocking malware, cryptojacking, scam, spam and phishing. Blocks domains known to spread malware, launch phishing attacks, and host command-and-control servers.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/wildcard/tif.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Hey @romaincointepas,

Thank you for merging a previously popular pull request: https://github.com/nextdns/blocklists/pull/65. By extension, many of us would also like to also have Hagezi's Threat Intelligence Feeds (TIF) to compliment our other blocklists.

Please offer @hagezi's TIF blocklist as an option. Details: https://github.com/hagezi/dns-blocklists#tif

Thanks for your support,

yokoffing
Maintainer of [NextDNS Config](https://github.com/yokoffing/NextDNS-Config) guide