### PR TITLE
TTC-CERT blocklist in ttc-cert.json

### DIFF
--- a/blocklists/ttc-cert.json
+++ b/blocklists/ttc-cert.json
@@ -1,0 +1,9 @@
+{
+  "name": "Thailand Telecommunications Sector CERT (TTC-CERT) Recommended Blocklist",
+  "website": "https://github.com/ttc-cert/TTC-CERT_blocklist_recommended",
+  "description": "Blocklist from Thailand Telecommunications Sector CERT (TTC-CERT), compiled from publicly published threat lists, and TTC-CERT's own research.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/ttc-cert/TTC-CERT_blocklist_recommended/master/domain_blocklist_recommended.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
This is a list compiled by [Thailand Telecommunications Sector CERT (TTC-CERT)](https://www.ttc-cert.or.th/), publicly available with their GitHub at https://github.com/ttc-cert/TTC-CERT_blocklist_recommended/blob/master/domain_blocklist_recommended.txt.

There are other blocking formats as well, but I believe this domain list do the job.