### PR TITLE
Unblock protondb.com from GoodbyeAds

### DIFF
--- a/blocklists/goodbye-ads.json
+++ b/blocklists/goodbye-ads.json
@@ -6,4 +6,7 @@
     "url": "https://raw.githubusercontent.com/jerryn70/GoodbyeAds/master/Hosts/GoodbyeAds.txt",
     "format": "hosts"
   }
+  "exclusions": [
+    "protondb.com"
+  ]
 }


### PR DESCRIPTION
GoodbyeAds blocks netlify.com, and protondb.com by default calls there, and therefore is blocked despite being a legitimate website.