### PR TITLE
 Add BetBlocker blocklist for betting sites

### DIFF
--- a/blocklists/bet-blocker.json
+++ b/blocklists/bet-blocker.json
@@ -1,0 +1,9 @@
+{
+  "name": "BetBlocker",
+  "website": "https://github.com/bet-blocker",
+  "description": "BetBlocker is an open-source blocklist containing domains of online betting sites, helping to create a safer digital environment and mitigate the risks associated with gambling.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/bet-blocker/bet-blocker/main/blocklist.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
This pull request adds a new open-source blocklist to the repository, containing domains of online betting sites. The list is designed to help block access to gambling websites, promoting a safer and more focused digital environment.