### PR TITLE
Create Axel Springer SE Blocklist

### DIFF
--- a/blocklists/axel-springer.json
+++ b/blocklists/axel-springer.json
@@ -1,0 +1,9 @@
+{
+  "name": "Axel Springer Blocklist",
+  "website": "https://github.com/autinerd/anti-axelspringer-hosts",
+  "description": "This file blocks all connections to sites which are from Axel Springer Verlag or have a connection with them.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/autinerd/anti-axelspringer-hosts/master/axelspringer-hosts",
+    "format": "hosts"
+  }
+}


### PR DESCRIPTION
### Rationale

This PR proposes adding Axel Springer SE and its subsidiaries to the blocklists due to recent events and a history of controversial practices:

1. **Promotion of far-right content**: Axel Springer's Die Welt recently published a guest article by Elon Musk endorsing the far-right AfD party, which is under surveillance by German intelligence for extremism[1][2][5][6][8]. This has caused significant controversy and resignations within the company.

2. **Editorial interference**: There have been accusations of editorial interference to support right-wing causes, including in Poland[3].

3. **Biased reporting**: The company has been criticized for anti-Muslim and anti-Palestinian bias in its reporting[3].

4. **Ethical concerns**: There's a history of compromising journalistic ethics, including allegations of sexual misconduct and questionable business practices[3][4].

5. **Historical issues**: Axel Springer has a decades-long record of mixing journalism with right-wing politics, including redbaiting during the Cold War[7].

6. **Controversial practices**: The company's tabloid Bild has been accused of using fake quotes and sensationalist tactics[7].

Adding Axel Springer SE to my personal blocklist would help maintain the integrity of my network and avoid association with potentially biased or extremist content.

Citations:
[1] https://www.telegraph.co.uk/news/2024/12/28/has-elon-musk-and-die-welt-made-germany-afd-salonfhig/
[2] https://www.motherjones.com/politics/2024/12/elon-musk-applauds-the-german-neo-nazi-party/
[3] https://en.wikipedia.org/wiki/Axel_Springer_SE#Criticism
[4] https://www.nytimes.com/2023/04/17/world/europe/axel-springer-ceo-apologizes-for-remarks.html
[5] https://www.euronews.com/2024/12/21/elon-musk-sparks-controversy-in-germany-over-afd-endorsement
[6] https://www.msnbc.com/rachel-maddow-show/maddowblog/elon-musk-germany-far-right-party-afd-rcna185065
[7] https://foreignpolicy.com/2022/01/06/axel-springer-politico-media-scandal-germany-bild/
[8] https://www.bluewin.ch/en/news/international/elon-musk-praises-the-afd-in-guest-article-opinion-leader-quits-2501969.html