### PR TITLE
Add ph00lt0-blocklist

### DIFF
--- a/blocklists/ph00lt0-blocklist
+++ b/blocklists/ph00lt0-blocklist
@@ -1,0 +1,9 @@
+{
+  "name": "ph00lt0 - Blocklist",
+  "website": "https://github.com/ph00lt0/blocklist",
+  "description": "This blocklist aims to block a variety of unwanted categories, including advertising and tracking tools like ads, stats and analytics, consent/cookie management platforms, debugging trackers; data collection and privacy risks posed by data brokers and data collecting companies such as surveys, as well as domains used in email spam activity; security threats such as malware, remote desktop software, phishing attempts, and spyware; scams and fraud, including quackery and lottery and gambling companies;",
+  "source": {
+    "url": "https://raw.githubusercontent.com/ph00lt0/blocklist/refs/heads/master/hosts-blocklist.txt",
+    "format": "hosts"
+  }
+}


### PR DESCRIPTION
Hey there.

I think it would be beneficial to add my blocklist to NextDNS. The is pretty actively updated (more than many of your current curated lists) and has gotten quite a user base over the last years. I have quite a lot of domains listed of various countries and categories that are missing in the current available lists.

If you prefer any other format let me know. I have quite some available but adding any other isn't an issue. 