### PR TITLE
Add fabriziosalmi blacklists

### DIFF
--- a/blocklists/fabriziosalmi-blacklists.json
+++ b/blocklists/fabriziosalmi-blacklists.json
@@ -1,0 +1,9 @@
+{
+  "name": "fabriziosalmi blacklists",
+  "website": "https://github.com/fabriziosalmi/blacklists",
+  "description": "This blacklist contains domains that are considered harmful or malicious and most of the ad and trackers out there. Regularly updating your systems with this list can help in safeguarding your digital assets.",
+  "source": {
+    "url": "https://github.com/fabriziosalmi/blacklists/releases/download/latest/blacklist.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Hi @romaincointepas and @rs .
I think it would be useful to add the [fabriziosalmi blocklist](https://github.com/fabriziosalmi/blacklists) to NextDNS because contains domains that are considered harmful or malicious and most of the ad and trackers out there.
It is actively updated (more than many of your current curated lists) as it is updated every hour.
It has quite a few domains listed from various countries that are missing from the current available lists.