### PR TITLE
add “AWAvenue Ads Rule”

### DIFF
--- a/blocklists/awavenue-ads-rule.json
+++ b/blocklists/awavenue-ads-rule.json
@@ -1,0 +1,9 @@
+{
+  "name": "AWAvenue Ads Rule",
+  "website": "https://github.com/TG-Twilight/AWAvenue-Ads-Rule",
+  "description": "Use Adblock syntax to fight against various advertising SDKs in Android applications from the network level , prevent them from loading.",
+  "source": {
+    "url": "https://raw.githubusercontent.com/TG-Twilight/AWAvenue-Ads-Rule/main/AWAvenue-Ads-Rule.txt",
+    "format": "abp"
+  }
+}

--- a/blocklists/awavenue-ads-rule.json
+++ b/blocklists/awavenue-ads-rule.json
@@ -1,7 +1,7 @@
 {
   "name": "AWAvenue Ads Rule",
   "website": "https://github.com/TG-Twilight/AWAvenue-Ads-Rule",
-  "description": "Use Adblock syntax to fight against various advertising SDKs in Android applications from the network level , prevent them from loading.",
+  "description": "开源社区中最优秀的广告过滤器列表之一，实现了最优秀的广告拦截、隐私保护和流量节省。",
   "source": {
     "url": "https://raw.githubusercontent.com/TG-Twilight/AWAvenue-Ads-Rule/main/AWAvenue-Ads-Rule.txt",
     "format": "abp"


### PR DESCRIPTION
Hello everyone, let me briefly introduce us:

_One of the best ad filters in the open-source community, the [AWAvenue Ads Rule](https://github.com/TG-Twilight/AWAvenue-Ads-Rule) offers exceptional ad-blocking, privacy protection, and traffic saving. It supports a variety of common network-layer ad-blocking tools and proxy solutions. Compared to other ad filters that rely on thousands of rules, the AWAvenue Ads Rule stands out with its ultra-efficient size control, high hit rate, and low hardware requirements._

We believe Next DNS is one of the best DNS services, and we share the same philosophy (open-source, privacy protection, and resisting harmful ads). Therefore, I hope to add our ad rules to Next DNS to create a cleaner and more refreshing internet experience for everyone!