### PR TITLE
Fix incorrect source URL in hufilter.json

### DIFF
--- a/blocklists/hufilter.json
+++ b/blocklists/hufilter.json
@@ -3,7 +3,7 @@
   "website": "https://github.com/hufilter/hufilter",
   "description": "Block hungarian ads.",
   "source": {
-    "url": "https://raw.githubusercontent.com/hufilter/hufilter/master/hufilter-dns.txt",
+    "url": "https://raw.githubusercontent.com/hufilter/hufilter/refs/heads/gh-pages/hufilter-dns.txt",
     "format": "domains"
   }
 }


### PR DESCRIPTION
The previous link was outdated/incorrect, and it has been replaced with the correct one. This ensures accurate data retrieval for the blocklist.