### PR TITLE
Add five DNS blocklists derived from the University of Toulouse 1 (UT1) public blacklists

### DIFF
--- a/blocklists/ut1actuality.json
+++ b/blocklists/ut1actuality.json
@@ -1,0 +1,9 @@
+{
+  "name": "UT1 bundle actuality",
+  "website": "https://github.com/Guernesey/utonextdns",
+  "description": "Combined UT1 categories: press, radio, fakenews, sports",
+  "source": {
+    "url": "https://raw.githubusercontent.com/Guernesey/utonextdns/main/dist/UT1-actuality.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/ut1adult1.json
+++ b/blocklists/ut1adult1.json
@@ -1,0 +1,9 @@
+{
+  "name": "UT1 bundle adult",
+  "website": "https://github.com/Guernesey/utonextdns",
+  "description": "Combined UT1 categories: adult — Bundle split into 2 parts: ut1adult.json, ut1adult2.json. Ajoutez-les toutes. — Ajouter aussi ut1adult2.json",
+  "source": {
+    "url": "https://raw.githubusercontent.com/Guernesey/utonextdns/main/dist/UT1-adult-1.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/ut1adult2.json
+++ b/blocklists/ut1adult2.json
@@ -1,0 +1,9 @@
+{
+  "name": "UT1 bundle adult",
+  "website": "https://github.com/Guernesey/utonextdns",
+  "description": "Combined UT1 categories: adult — Bundle split into 2 parts: ut1adult.json, ut1adult2.json. Ajoutez-les toutes. — Ajouter aussi ut1adult1.json",
+  "source": {
+    "url": "https://raw.githubusercontent.com/Guernesey/utonextdns/main/dist/UT1-adult-2.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/ut1financial.json
+++ b/blocklists/ut1financial.json
@@ -1,0 +1,9 @@
+{
+  "name": "UT1 bundle financial",
+  "website": "https://github.com/Guernesey/utonextdns",
+  "description": "Combined UT1 categories: financial, bitcoin, cryptojacking",
+  "source": {
+    "url": "https://raw.githubusercontent.com/Guernesey/utonextdns/main/dist/UT1-financial.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/ut1sensitive.json
+++ b/blocklists/ut1sensitive.json
@@ -1,0 +1,9 @@
+{
+  "name": "UT1 bundle sensitive",
+  "website": "https://github.com/Guernesey/utonextdns",
+  "description": "Combined UT1 categories: agressif, drogue, lingerie, sexual_education, dating, celebrity, mixed_adult",
+  "source": {
+    "url": "https://raw.githubusercontent.com/Guernesey/utonextdns/main/dist/UT1-sensitive.txt",
+    "format": "domains"
+  }
+}

--- a/blocklists/ut1shopping.json
+++ b/blocklists/ut1shopping.json
@@ -1,0 +1,9 @@
+{
+  "name": "UT1 bundle shopping",
+  "website": "https://github.com/Guernesey/utonextdns",
+  "description": "Combined UT1 categories: shopping",
+  "source": {
+    "url": "https://raw.githubusercontent.com/Guernesey/utonextdns/main/dist/UT1-shopping.txt",
+    "format": "domains"
+  }
+}


### PR DESCRIPTION
Hello,

Existing lists are excellent at blocking pornography and common internet threats. The University of Toulouse 1 (UT1) lists go a step further by allowing more granular filtering, such as **Sensitive** content or **News/Press** categories. This is particularly useful for students and educational environments, where balancing open access to information with a safe browsing experience is key.

This PR introduces a set of automated DNS blocklists derived from the University of Toulouse 1 (UT1) public blacklists. These lists are specifically formatted for NextDNS and are automatically updated daily via GitHub Actions.

The bundles group related UT1 categories into logical filters to simplify policy management:

* **Actuality:** Combines `press`, `radio`, `fakenews`, and `sports`.
* **Sensitive:** Mature content including `agressif`, `drogue`, `lingerie`, `sexual_education`, `dating`, `celebrity`, and `mixed_adult`.
* **Financial:** Focuses on `financial`, `bitcoin`, and `cryptojacking`.
* **Shopping:** Includes `shopping`, `ads`, and `marketing`.
* **Adult:** Standard adult category, split into two parts to comply with GitHub's file size limits and ensure optimal processing.

### Technical Details

* **Source:** [UT1 Blacklists](https://dsi.ut-capitole.fr/blacklists/)
* **Update Frequency:** Daily at 02:22 UTC.
* **Format:** Domain-based `.txt` files located in the `/dist` directory.
* **Automation:** Powered by Python and GitHub Actions to ensure zero-day synchronization with upstream changes.

Thank you.